### PR TITLE
Cgivar2vcf updates

### DIFF
--- a/file_process/utils/_twobit.pyx
+++ b/file_process/utils/_twobit.pyx
@@ -12,7 +12,7 @@ cdef extern from "Python.h":
 
 cdef extern from "ctype.h":
     int tolower(int)
-    
+
 cdef extern from "string.h":
     void * memset(void *, int, int)
 
@@ -31,7 +31,9 @@ def read(file, seq, int fragStart, int fragEnd, do_mask=False):
     cdef int pOff, pStart, pEnd
     cdef int midStart, remainder, partCount
     cdef int i, j, s, e
-    cdef char * packed, * dna, * dna_orig
+    cdef char * packed
+    cdef char * dna
+    cdef char * dna_orig
     cdef char partial
     packedStart = (fragStart>>2);
     packedEnd = ((fragEnd+3)>>2);
@@ -43,7 +45,7 @@ def read(file, seq, int fragStart, int fragEnd, do_mask=False):
     file.seek(seq.sequence_offset + packedStart)
     packed_py = file.read(packByteCount)
     packed = PyString_AsString(packed_py)
-    # Handle case where everything is in one packed byte 
+    # Handle case where everything is in one packed byte
     if packByteCount == 1:
         pOff = (packedStart<<2)
         pStart = fragStart - pOff
@@ -80,7 +82,7 @@ def read(file, seq, int fragStart, int fragEnd, do_mask=False):
             dna[1] = valToNt[partial&3];
             partial = partial >> 2
             dna[0] = valToNt[partial&3];
-            dna = dna + 4;            
+            dna = dna + 4;
             # Increment
             i = i + 4
             ## sys.stderr.write("!!!< " + dna_py + " >!!!\n"); sys.stderr.flush()
@@ -97,7 +99,7 @@ def read(file, seq, int fragStart, int fragEnd, do_mask=False):
     n_block_count = len(seq.n_block_starts)
     if n_block_count > 0:
         start_ix = bisect(seq.n_block_starts, fragStart) - 1
-        if start_ix < 0: start_ix = 0            
+        if start_ix < 0: start_ix = 0
         for i from start_ix <= i < n_block_count:
             s = seq.n_block_starts[i];
             e = s + seq.n_block_sizes[i];
@@ -114,7 +116,7 @@ def read(file, seq, int fragStart, int fragEnd, do_mask=False):
         m_block_count = len(seq.masked_block_starts)
         if m_block_count > 0:
             start_ix = bisect(seq.masked_block_starts, fragStart) - 1
-            if start_ix < 0: start_ix = 0    
+            if start_ix < 0: start_ix = 0
             for i from start_ix <= i < m_block_count:
                 s = seq.masked_block_starts[i];
                 e = s + seq.masked_block_sizes[i];

--- a/file_process/utils/cgivar_to_vcf.py
+++ b/file_process/utils/cgivar_to_vcf.py
@@ -9,10 +9,9 @@ import gzip
 import re
 import sys
 
-from optparse import OptionParser
+from argparse import ArgumentParser
 
 from get_reference import get_reference_allele
-
 
 def auto_zip_open(filepath, mode):
     """Convenience function for opening potentially-compressed files."""
@@ -252,24 +251,37 @@ def convert_to_file(cgi_input, output_file, twobit_ref):
 
 def main():
     # Parse options
-    usage = "\n%prog -i inputfile [-o outputfile]\n" \
-            + "%prog [-o outputfile] < inputfile"
-    parser = OptionParser(usage=usage)
-    parser.add_option("-i", "--input", dest="inputfile",
+    parser = ArgumentParser()
+
+    parser.add_argument("-i", "--input", dest="inputfile",
                       help="read CGI data from INFILE (uncompressed, .gz," +
                       " or .bz2)", metavar="INFILE")
-    parser.add_option("-o", "--output", dest="outputfile",
+    parser.add_argument("-o", "--output", dest="outputfile",
                       help="write report to OUTFILE (uncompressed, " +
                       "*.gz, or *.bz2)", metavar="OUTFILE")
-    parser.add_option("-r", "--ref2bit", dest="twobitref",
+    parser.add_argument("-r", "--ref2bit", dest="twobitref",
                       help="2bit reference genome file",
                       metavar="TWOBITREF")
-    options, _ = parser.parse_args()
+    options = parser.parse_args()
+
+
     # Handle input
     if sys.stdin.isatty():  # false if data is piped in
+        if options.inputfile:
+          var_input = options.inputfile
+        else:
+          print "Provide CGI input file\n"
+          parser.print_help()
+          sys.exit(1)
         var_input = options.inputfile
     else:
         var_input = sys.stdin
+
+    if not options.twobitref:
+      print "Provide 2bit refernce file\n"
+      parser.print_help()
+      sys.exit(1)
+
     # Handle output
     if options.outputfile:
         convert_to_file(var_input, options.outputfile, options.twobitref)

--- a/file_process/utils/get_reference.py
+++ b/file_process/utils/get_reference.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from .twobit import TwoBitFile
+from twobit import TwoBitFile
 
 
 def get_reference_allele(chrom, start, hg19_path):


### PR DESCRIPTION
Some (hopefully) trivial changes and cleanup:
- `cgivar_to_vcf.py` wouldn't run unless I included 'twobit' from `get_reference.py` (instead of 'import .twobit')
- Added some simple input checking for parameters passed to `cgvar_to_vcf.py` from the command line.
- Updated the option parser.
